### PR TITLE
Fixed image flipping while quick scaling

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/CustomGestureDetector.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/CustomGestureDetector.java
@@ -56,8 +56,11 @@ class CustomGestureDetector {
                 if (Float.isNaN(scaleFactor) || Float.isInfinite(scaleFactor))
                     return false;
 
-                mListener.onScale(scaleFactor,
-                        detector.getFocusX(), detector.getFocusY());
+                if (scaleFactor >= 0) {
+                    mListener.onScale(scaleFactor,
+                            detector.getFocusX(), detector.getFocusY());
+                }
+
                 return true;
             }
 


### PR DESCRIPTION
### Bug Description
Good bug description here - [Quick Scale issue](https://github.com/signalapp/Signal-Android/issues/8061). This issue is caused by broken method `getScaleFactor()` in `ScaleGestureDetector.java`:
```
public float getScaleFactor() {
     if (inAnchoredScaleMode()) {
         // Drag is moving up; the further away from the gesture
         // start, the smaller the span should be, the closer,
         // the larger the span, and therefore the larger the scale
         final boolean scaleUp =
                 (mEventBeforeOrAboveStartingGestureEvent && (mCurrSpan < mPrevSpan)) ||
                 (!mEventBeforeOrAboveStartingGestureEvent && (mCurrSpan > mPrevSpan));
         final float spanDiff = (Math.abs(1 - (mCurrSpan / mPrevSpan)) * SCALE_FACTOR);
         return mPrevSpan <= 0 ? 1 : scaleUp ? (1 + spanDiff) : (1 - spanDiff);
     }
     return mPrevSpan > 0 ? mCurrSpan / mPrevSpan : 1;
 }
```

When user quick scaling fast, this can happen `mPrevSpan < mCurrSpan && mEventBeforeOrAboveStartingGestureEvent == true` so `scaleFlag == false` and if `mCurrSpan` is much bigger than `mPrevSpan` for example `mCurrSpan == 337` and `mPastSpan == 1248`. In this case `spanDiff == 1.35` and return statement will evaluate `1 - spanDiff` which leads to `scaleFactor` below zero and image rotate 180 degrees.  

This is already known issue, but google hasn't fixed it - [Google ticket](https://issuetracker.google.com/issues/37129701)

The easiest way to fix it is just don't scale when `scaleFactor < 0`. You can test this solution, this is almost impossible to notice that image not scaling sometimes. And this is much better than flipped image.
