### PR TITLE
Added image bounce on scaling down

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -145,7 +145,7 @@ public class PhotoViewAttacher implements View.OnTouchListener,
 
         @Override
         public void onScale(float scaleFactor, float focusX, float focusY) {
-            if ((getScale() < mMaxScale || scaleFactor < 1f) && (getScale() > mMinScale || scaleFactor > 1f)) {
+            if (getScale() < mMaxScale || scaleFactor < 1f) {
                 if (mScaleChangeListener != null) {
                     mScaleChangeListener.onScaleChange(scaleFactor, focusX, focusY);
                 }


### PR DESCRIPTION
Removed scaling down restriction in order to let image bounce from scaled down size to normal size. This is how it looks now:
![photoviewbounce](https://user-images.githubusercontent.com/7988176/49159031-9a74e080-f334-11e8-9852-552c040ead5e.gif)
