### PR TITLE
Maven publishing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }
 

--- a/gallery/build.gradle
+++ b/gallery/build.gradle
@@ -21,7 +21,7 @@ android {
         }
     }
 }
-
+//We need to place this apply below android section because publishing.gradle needs compileSdkVersion
 apply from: 'publishing.gradle'
 
 ext {

--- a/gallery/build.gradle
+++ b/gallery/build.gradle
@@ -1,12 +1,10 @@
 plugins {
     id "com.jfrog.bintray" version "1.8.4"
 }
-
+apply plugin: 'maven-publish'
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'maven-publish'
-apply plugin: 'maven'
 
 android {
 
@@ -50,95 +48,4 @@ dependencies {
     // Image loader
     implementation 'com.github.bumptech.glide:glide:4.7.1'
 }
-
-// Uploading
-
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-
-bintray {
-    user = properties.getProperty("bintrayUser")
-    key = properties.getProperty("bintrayApiKey")
-    publications = ['GalleryPublication']
-    pkg {
-        repo = 'android-maven'
-        name = 'android-gallery'
-        userOrg = 'rmrspb'
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/redmadrobot-spb/android-gallery.git'
-
-        version {
-            name = '1.0.0'
-        }
-    }
-}
-
-//pomconfig for publishinig in maven central
-
-def pomConfig = {
-    licenses {
-        license {
-            name "MIT license"
-            url "http://www.opensource.org/licenses/mit-license.php"
-            distribution "repo"
-        }
-    }
-
-    developers {
-        developer {
-//            developer info here
-        }
-    }
-
-    scm {
-        url "https://github.com/redmadrobot-spb/android-gallery.git"
-    }
-}
-
-publishing {
-    publications {
-        GalleryPublication(MavenPublication) {
-            groupId 'com.redmadrobot.gallery'
-            artifactId 'android-gallery'
-            version '1.0.0'
-
-            artifact("$buildDir/outputs/aar/gallery-release.aar")
-            artifact sourcesJar
-            artifact javadocJar
-
-            pom.withXml {
-                def root = asNode()
-                def dependenciesNode = root.appendNode('dependencies')
-                // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                configurations.implementation.allDependencies.each {
-                    // Ensure dependencies such as fileTree are not included.
-                    if (it.name != 'unspecified') {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
-                    }
-                }
-                root.children().first() + pomConfig
-            }
-        }
-    }
-}
-
-// Tasks for sources and javadocs jars
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.sourceFiles
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.compile
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
+apply from: 'publishing.gradle'

--- a/gallery/build.gradle
+++ b/gallery/build.gradle
@@ -1,6 +1,12 @@
+plugins {
+    id "com.jfrog.bintray" version "1.8.4"
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'maven-publish'
+apply plugin: 'maven'
 
 android {
 
@@ -23,6 +29,9 @@ android {
 
 ext {
     exoPlayerVersion = "2.8.3"
+    libraryVersion = '1.0.0'
+    publishedGroupId = 'com.redmadrobot.gallery'
+    artifact = 'android-gallery'
 }
 
 dependencies {
@@ -41,3 +50,95 @@ dependencies {
     // Image loader
     implementation 'com.github.bumptech.glide:glide:4.7.1'
 }
+
+// Uploading
+
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty("bintrayUser")
+    key = properties.getProperty("bintrayApiKey")
+    publications = ['GalleryPublication']
+    pkg {
+        repo = 'android-maven'
+        name = 'android-gallery'
+        userOrg = 'rmrspb'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/redmadrobot-spb/android-gallery.git'
+
+        version {
+            name = '1.0.0'
+        }
+    }
+}
+
+//pomconfig for publishinig in maven central
+
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT license"
+            url "http://www.opensource.org/licenses/mit-license.php"
+            distribution "repo"
+        }
+    }
+
+    developers {
+        developer {
+//            developer info here
+        }
+    }
+
+    scm {
+        url "https://github.com/redmadrobot-spb/android-gallery.git"
+    }
+}
+
+publishing {
+    publications {
+        GalleryPublication(MavenPublication) {
+            groupId 'com.redmadrobot.gallery'
+            artifactId 'android-gallery'
+            version '1.0.0'
+
+            artifact("$buildDir/outputs/aar/gallery-release.aar")
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom.withXml {
+                def root = asNode()
+                def dependenciesNode = root.appendNode('dependencies')
+                // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                configurations.implementation.allDependencies.each {
+                    // Ensure dependencies such as fileTree are not included.
+                    if (it.name != 'unspecified') {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+                root.children().first() + pomConfig
+            }
+        }
+    }
+}
+
+// Tasks for sources and javadocs jars
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+

--- a/gallery/build.gradle
+++ b/gallery/build.gradle
@@ -1,6 +1,3 @@
-plugins {
-    id "com.jfrog.bintray" version "1.8.4"
-}
 apply plugin: 'maven-publish'
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
@@ -25,6 +22,8 @@ android {
     }
 }
 
+apply from: 'publishing.gradle'
+
 ext {
     exoPlayerVersion = "2.8.3"
     libraryVersion = '1.0.0'
@@ -48,4 +47,3 @@ dependencies {
     // Image loader
     implementation 'com.github.bumptech.glide:glide:4.7.1'
 }
-apply from: 'publishing.gradle'

--- a/gallery/publishing.gradle
+++ b/gallery/publishing.gradle
@@ -35,9 +35,6 @@ def pomConfig = {
     }
 
     developers {
-        developer {
-//            developer info here
-        }
     }
 
     scm {
@@ -59,7 +56,6 @@ publishing {
             pom.withXml {
                 def root = asNode()
                 def dependenciesNode = root.appendNode('dependencies')
-
                 configurations.implementation.allDependencies.each {
                     if (it.name != 'unspecified') {
                         def dependencyNode = dependenciesNode.appendNode('dependency')

--- a/gallery/publishing.gradle
+++ b/gallery/publishing.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'com.jfrog.bintray'
+
 ext {
     gitUrl = "https://github.com/redmadrobot-spb/android-gallery.git"
     projectName = 'android-gallery'

--- a/gallery/publishing.gradle
+++ b/gallery/publishing.gradle
@@ -1,3 +1,8 @@
+ext {
+    gitUrl = "https://github.com/redmadrobot-spb/android-gallery.git"
+    projectName = 'android-gallery'
+}
+
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
@@ -7,10 +12,10 @@ bintray {
     publications = ['GalleryPublication']
     pkg {
         repo = 'android-maven'
-        name = 'android-gallery'
+        name = projectName
         userOrg = 'rmrspb'
         licenses = ['MIT']
-        vcsUrl = 'https://github.com/redmadrobot-spb/android-gallery.git'
+        vcsUrl = gitUrl
 
         version {
             name = '1.0.0'
@@ -36,7 +41,7 @@ def pomConfig = {
     }
 
     scm {
-        url "https://github.com/redmadrobot-spb/android-gallery.git"
+        url gitUrl
     }
 }
 
@@ -44,7 +49,7 @@ publishing {
     publications {
         GalleryPublication(MavenPublication) {
             groupId 'com.redmadrobot.gallery'
-            artifactId 'android-gallery'
+            artifactId projectName
             version '1.0.0'
 
             artifact("$buildDir/outputs/aar/gallery-release.aar")

--- a/gallery/publishing.gradle
+++ b/gallery/publishing.gradle
@@ -1,0 +1,88 @@
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty("bintrayUser")
+    key = properties.getProperty("bintrayApiKey")
+    publications = ['GalleryPublication']
+    pkg {
+        repo = 'android-maven'
+        name = 'android-gallery'
+        userOrg = 'rmrspb'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/redmadrobot-spb/android-gallery.git'
+
+        version {
+            name = '1.0.0'
+        }
+    }
+}
+
+//pomConfig for publishing in maven central
+
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT license"
+            url "http://www.opensource.org/licenses/mit-license.php"
+            distribution "repo"
+        }
+    }
+
+    developers {
+        developer {
+//            developer info here
+        }
+    }
+
+    scm {
+        url "https://github.com/redmadrobot-spb/android-gallery.git"
+    }
+}
+
+publishing {
+    publications {
+        GalleryPublication(MavenPublication) {
+            groupId 'com.redmadrobot.gallery'
+            artifactId 'android-gallery'
+            version '1.0.0'
+
+            artifact("$buildDir/outputs/aar/gallery-release.aar")
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom.withXml {
+                def root = asNode()
+                def dependenciesNode = root.appendNode('dependencies')
+
+                configurations.implementation.allDependencies.each {
+                    if (it.name != 'unspecified') {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+                root.children().first() + pomConfig
+            }
+        }
+    }
+}
+
+// Tasks for sources and javadocs jars
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+


### PR DESCRIPTION
Add working publication script.

These changes allow to publish library into bintray by calling `bintrayUpload` task. But PhotoView dependency requires jitpack, so library's user must add this repository in his project.